### PR TITLE
Add zh-TW locale support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Wiki.js Configuration
 WIKIJS_GRAPHQL_URL=https://wiki.example.com/graphql
 WIKIJS_API_TOKEN=your_wikijs_api_token_here
+WIKIJS_LOCALE=zh-TW

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -37,6 +37,7 @@ cp .env.example .env
    - `OPENAI_API_KEY`: 你的 OpenAI API 金鑰
    - `WIKIJS_GRAPHQL_URL`: 你的 Wiki.js GraphQL URL
    - `WIKIJS_API_TOKEN`: 你的 Wiki.js API 令牌
+   - `WIKIJS_LOCALE`: 條目預設語言 (預設 `zh-TW`)
 
 ### 3. 其他雲端平台
 
@@ -46,6 +47,7 @@ cp .env.example .env
 vercel env add OPENAI_API_KEY
 vercel env add WIKIJS_GRAPHQL_URL
 vercel env add WIKIJS_API_TOKEN
+vercel env add WIKIJS_LOCALE
 ```
 
 #### Heroku
@@ -54,6 +56,7 @@ vercel env add WIKIJS_API_TOKEN
 heroku config:set OPENAI_API_KEY=your_key
 heroku config:set WIKIJS_GRAPHQL_URL=your_url
 heroku config:set WIKIJS_API_TOKEN=your_token
+heroku config:set WIKIJS_LOCALE=zh-TW
 ```
 
 #### Docker
@@ -62,6 +65,7 @@ heroku config:set WIKIJS_API_TOKEN=your_token
 docker run -e OPENAI_API_KEY=your_key \
            -e WIKIJS_GRAPHQL_URL=your_url \
            -e WIKIJS_API_TOKEN=your_token \
+           -e WIKIJS_LOCALE=zh-TW \
            your_image
 ```
 
@@ -82,6 +86,7 @@ docker run -e OPENAI_API_KEY=your_key \
 python -c "import os; print('OPENAI_API_KEY:', 'SET' if os.getenv('OPENAI_API_KEY') else 'NOT SET')"
 python -c "import os; print('WIKIJS_GRAPHQL_URL:', 'SET' if os.getenv('WIKIJS_GRAPHQL_URL') else 'NOT SET')"
 python -c "import os; print('WIKIJS_API_TOKEN:', 'SET' if os.getenv('WIKIJS_API_TOKEN') else 'NOT SET')"
+python -c "import os; print('WIKIJS_LOCALE:', os.getenv('WIKIJS_LOCALE', 'zh-TW'))"
 
 # 測試基本功能
 python test_basic.py

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 3. **避免知識碎片化**: 智能檢測現有相關條目，建議合併而非重複建立
 4. **符合 APA 8 引用格式**: 自動產生符合學術標準的引用
 5. **模組化設計**: 遵循 SOLID 原則，程式碼易於維護和擴充
+6. **繁體中文支援**: 建立 Wiki.js 條目時使用繁體中文，References 保持原文
 
 ## 快速開始
 
@@ -110,6 +111,7 @@ python main.py
 - 所有條目包含 APA 8 格式引用
 - 標註每段內容的出處
 - 維護完整的參考文獻列表
+- 參考文獻維持原文語言
 
 ## 配置設定
 
@@ -132,6 +134,7 @@ python main.py
   # Wiki.js Configuration  
   WIKIJS_GRAPHQL_URL=https://your-wiki.domain/graphql
   WIKIJS_API_TOKEN=your_jwt_token_here
+  WIKIJS_LOCALE=zh-TW
 
   # Optional: Configure base URL for other providers
   # OPENAI_BASE_URL=https://api.openai.com/v1

--- a/src/paper2wikijs/wikijs_client.py
+++ b/src/paper2wikijs/wikijs_client.py
@@ -27,6 +27,7 @@ class WikiJSClient:
         # 優先從環境變數取得設定
         self.wiki_url = os.getenv("WIKIJS_GRAPHQL_URL")
         self.api_token = os.getenv("WIKIJS_API_TOKEN")
+        self.locale = os.getenv("WIKIJS_LOCALE")
 
         # 如果環境變數中沒有，嘗試從配置檔案讀取
         if not self.wiki_url or not self.api_token:
@@ -38,6 +39,8 @@ class WikiJSClient:
                     self.wiki_url = config["wiki.js"]["graphql_url"]
                 if not self.api_token:
                     self.api_token = config["wiki.js"]["api"]
+                if not self.locale:
+                    self.locale = config["wiki.js"].get("locale")
             except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
                 raise ValueError(
                     f"無法從環境變數或配置檔案取得 Wiki.js 設定。"
@@ -49,6 +52,8 @@ class WikiJSClient:
             raise ValueError(
                 "Wiki.js 設定不完整。請確保設定了 WIKIJS_GRAPHQL_URL 和 WIKIJS_API_TOKEN"
             )
+        if not self.locale:
+            self.locale = "zh-TW"
 
         self.headers = {
             "Authorization": f"Bearer {self.api_token}",
@@ -166,8 +171,8 @@ class WikiJSClient:
             建立結果
         """
         create_query = """
-        mutation CreatePage($title: String!, $content: String!, $path: String!, $tags: [String!]!, $description: String!) {
-          pages {
+        mutation CreatePage($title: String!, $content: String!, $path: String!, $tags: [String!]!, $description: String!) {{
+          pages {{
             create(
               title: $title
               content: $content
@@ -175,20 +180,20 @@ class WikiJSClient:
               tags: $tags
               description: $description
               editor: "markdown"
-              locale: "en"
+              locale: "{locale}"
               isPublished: true
               isPrivate: false
-            ) {
-              responseResult {
+            ) {{
+              responseResult {{
                 succeeded
                 errorCode
                 slug
                 message
-              }
-            }
-          }
-        }
-        """
+              }}
+            }}
+          }}
+        }}
+        """.format(locale=self.locale)
 
         variables = {
             "title": title,
@@ -228,27 +233,27 @@ class WikiJSClient:
             更新結果
         """
         update_query = """
-        mutation UpdatePage($id: Int!, $title: String!, $content: String!, $tags: [String!]!) {
-          pages {
+        mutation UpdatePage($id: Int!, $title: String!, $content: String!, $tags: [String!]!) {{
+          pages {{
             update(
               id: $id
               title: $title
               content: $content
               tags: $tags
               editor: "markdown"
-              locale: "en"
+              locale: "{locale}"
               isPublished: true
-            ) {
-              responseResult {
+            ) {{
+              responseResult {{
                 succeeded
                 errorCode
                 slug
                 message
-              }
-            }
-          }
-        }
-        """
+              }}
+            }}
+          }}
+        }}
+        """.format(locale=self.locale)
 
         variables = {
             "id": page_id,


### PR DESCRIPTION
## Summary
- support configurable Wiki.js locale via `WIKIJS_LOCALE`
- note that Wiki.js entries use Traditional Chinese and keep references in original language
- document new environment variable in README and ENV_SETUP
- update example `.env`

## Testing
- `python -m compileall -q src/paper2wikijs`