### PR TITLE
Add SSL verify flags and tidy CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,19 +3,11 @@
 ScienceDaily 到 Wiki.js 的命令列工具
 """
 import argparse
-import sys
 import os
-from pathlib import Path
 from dotenv import load_dotenv
-
-# 載入環境變數
-load_dotenv()
-
-# 加入專案根目錄到 Python 路徑
-project_root = Path(__file__).parent
-sys.path.insert(0, str(project_root))
-
 from src.paper2wikijs import ScienceDaily2WikiService
+
+load_dotenv()
 
 
 def main():

--- a/src/paper2wikijs/knowledge_processor.py
+++ b/src/paper2wikijs/knowledge_processor.py
@@ -7,7 +7,6 @@ import os
 from typing import Dict, List, Tuple, Any
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.messages import SystemMessage, HumanMessage
 

--- a/src/paper2wikijs/sciencedaily_extractor.py
+++ b/src/paper2wikijs/sciencedaily_extractor.py
@@ -4,13 +4,20 @@ ScienceDaily 內容抓取器
 """
 
 import requests
+import os
 import re
-from typing import Dict, Optional
+from typing import Dict
 from bs4 import BeautifulSoup
 
 
 class ScienceDailyExtractor:
     """從 ScienceDaily 網站提取內容的類"""
+
+    def __init__(self) -> None:
+        """初始化，可透過環境變數控制 SSL 驗證"""
+        self.verify_ssl = (
+            os.getenv("SCIENTEDAILY_VERIFY_SSL", "true").lower() != "false"
+        )
 
     def extract_article_info(self, url: str) -> Dict[str, str]:
         """
@@ -22,7 +29,7 @@ class ScienceDailyExtractor:
         Returns:
             包含文章資訊的字典
         """
-        resp = requests.get(url)
+        resp = requests.get(url, verify=self.verify_ssl)
         soup = BeautifulSoup(resp.text, "html.parser")
 
         # Title

--- a/src/paper2wikijs/service.py
+++ b/src/paper2wikijs/service.py
@@ -3,7 +3,6 @@ ScienceDaily 到 Wiki 的主要服務類
 整合所有功能，實現從 ScienceDaily URL 到 Wiki 條目的完整流程
 """
 
-import os
 from typing import Dict, List
 from .sciencedaily_extractor import ScienceDailyExtractor
 from .wikijs_client import WikiJSClient

--- a/src/paper2wikijs/wikijs_client.py
+++ b/src/paper2wikijs/wikijs_client.py
@@ -28,6 +28,7 @@ class WikiJSClient:
         self.wiki_url = os.getenv("WIKIJS_GRAPHQL_URL")
         self.api_token = os.getenv("WIKIJS_API_TOKEN")
         self.locale = os.getenv("WIKIJS_LOCALE")
+        self.verify_ssl = os.getenv("WIKIJS_VERIFY_SSL", "true").lower() != "false"
 
         # 如果環境變數中沒有，嘗試從配置檔案讀取
         if not self.wiki_url or not self.api_token:
@@ -90,6 +91,7 @@ class WikiJSClient:
             self.wiki_url,
             json={"query": query, "variables": variables},
             headers=self.headers,
+            verify=self.verify_ssl,
         )
 
         if response.status_code == 200:
@@ -135,6 +137,7 @@ class WikiJSClient:
             self.wiki_url,
             json={"query": query_content, "variables": variables},
             headers=self.headers,
+            verify=self.verify_ssl,
         )
 
         response_data = response.json()
@@ -193,7 +196,9 @@ class WikiJSClient:
             }}
           }}
         }}
-        """.format(locale=self.locale)
+        """.format(
+            locale=self.locale
+        )
 
         variables = {
             "title": title,
@@ -207,6 +212,7 @@ class WikiJSClient:
             self.wiki_url,
             json={"query": create_query, "variables": variables},
             headers=self.headers,
+            verify=self.verify_ssl,
         )
 
         response_data = response.json()
@@ -253,7 +259,9 @@ class WikiJSClient:
             }}
           }}
         }}
-        """.format(locale=self.locale)
+        """.format(
+            locale=self.locale
+        )
 
         variables = {
             "id": page_id,
@@ -266,6 +274,7 @@ class WikiJSClient:
             self.wiki_url,
             json={"query": update_query, "variables": variables},
             headers=self.headers,
+            verify=self.verify_ssl,
         )
 
         response_data = response.json()


### PR DESCRIPTION
## Summary
- allow disabling SSL verification for wiki and ScienceDaily requests via env vars
- clean up CLI imports
- remove unused imports

## Testing
- `ruff check .`
- `black --check src/paper2wikijs cli.py`
- `python - <<'PY'\nfrom paper2wikijs.service import ScienceDaily2WikiService\nservice = ScienceDaily2WikiService()\nurl = 'http://www.sciencedaily.com/releases/2025/03/250324181544.htm'\nres = service.preview_analysis(url)\nprint(res['success'], res['article_info']['title'])\nPY`